### PR TITLE
Updated: Adding getConnection value to passthru properties

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -55,7 +55,7 @@ class Builder
      */
     protected $passthru = [
         'insert', 'insertGetId', 'getBindings', 'toSql',
-        'exists', 'count', 'min', 'max', 'avg', 'sum',
+        'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection'
     ];
 
     /**


### PR DESCRIPTION
Adding getConnection value to passthru properties to allow get Illuminate\Database\Connection Object using method getConnection of Illuminate\Database\Eloquent\Model, so can change fetch style to FETCH_NUM or do other functionality using Illuminate\Database\Connection Object
